### PR TITLE
Update tools, circularProfiles

### DIFF
--- a/OOPAO/tools/tools.py
+++ b/OOPAO/tools/tools.py
@@ -313,8 +313,8 @@ def compute_fourier_mode(pupil,spatial_frequency,angle_deg,zeropadding = 2):
     
     return mode
 
-#%%
-def circularProfile(img):
+
+def circularProfile(img, maximum = False):
     # Compute circular average profile from an image, reference to center of image
     # Get image parameters
     a = img.shape[0]
@@ -322,6 +322,13 @@ def circularProfile(img):
     # Image center
     cen_x = a//2
     cen_y = b//2
+
+    if maximum == True:
+        cogMaximum = cog(img)
+        cen_x = cogMaximum[0] + a/2
+        cen_y = cogMaximum[1] + b/2
+        print('Maximum position = [px]')
+        print(cen_x, cen_y)
     # Find radial distances
     [X, Y] = np.meshgrid(np.arange(b) - cen_x, np.arange(a) - cen_y)
     R = np.sqrt(np.square(X) + np.square(Y))

--- a/OOPAO/tools/tools.py
+++ b/OOPAO/tools/tools.py
@@ -324,7 +324,7 @@ def circularProfile(img, maximum = False):
     cen_y = b//2
 
     if maximum == True:
-        cogMaximum = cog(img)
+        cogMaximum = centroid(img,threshold = 0.1*img.max())
         cen_x = cogMaximum[0] + a/2
         cen_y = cogMaximum[1] + b/2
         print('Maximum position = [px]')


### PR DESCRIPTION
Added an option to tools.circularProfiles

Can do the circular profile around the peak position in the image, instead of the center of array (default). 