### PR TITLE
Small update in centroid function from SH

### DIFF
--- a/OOPAO/ShackHartmann.py
+++ b/OOPAO/ShackHartmann.py
@@ -301,7 +301,12 @@ class ShackHartmann:
         self.print_properties()
 
     def centroid(self, image, threshold=0.01):
-        im = np.atleast_3d(image.copy())
+
+        if np.ndim(image) <= 2:
+            im = np.reshape(image.copy(),(1, np.shape(image)[0], np.shape(image)[1]))
+        else:
+            im = np.atleast_3d(image.copy())
+
         im[im < (threshold*im.max())] = 0
         centroid_out = np.zeros([im.shape[0], 2])
         X_map, Y_map = np.meshgrid(
@@ -313,6 +318,7 @@ class ShackHartmann:
             np.sum(im*X_coord_map, axis=1), axis=1)/norma
         centroid_out[:, 1] = np.sum(
             np.sum(im*Y_coord_map, axis=1), axis=1)/norma
+
         return centroid_out
 
     def initialize_flux(self, input_flux_map=None):


### PR DESCRIPTION
Small update in Centroid function of SH. The np.atleast_3d function changes a 2D array (M*N) into a (M*N*1) 3D array. It should be instead a 3D array of shape (1*M*N) taking into account the way the centroid function is built. This allows to correctly use the centroid function of the SH also with 2D arrays.