### PR TITLE
Zernike normalization correction

### DIFF
--- a/OOPAO/Zernike.py
+++ b/OOPAO/Zernike.py
@@ -52,7 +52,8 @@ class Zernike:
                     m = abs(m)
                     Z = np.sqrt(2*(n+1)) * self.zernikeRadialFunc(n,
                                                                   m, R) * np.sin(m * theta)
-            if n!=0 and m!=0:
+            # if n!=0 and m!=0:
+            if n != 0:
                 Z -= Z.mean()
                 Z *= (1/np.std(Z))
 


### PR DESCRIPTION
Corrected normalization operation of Zernike modes. The elements with m = = 0 were not being normalized. Only piston cannot be normalized since std == 0. The others can all be normalized.