### PR TITLE
Add the Angular Spectrum propagation method to simulate scintillation cases

### DIFF
--- a/OOPAO/Asterism.py
+++ b/OOPAO/Asterism.py
@@ -140,6 +140,25 @@ class Asterism:
         for src in self.src:
             _OPD_no_pupil.append(src.OPD_no_pupil)
         return np.array(_OPD_no_pupil)
+    
+    @property
+    def scintillation(self):
+        _scintillation = []
+        for src in self.src:
+            _scintillation.append(getattr(src, 'scintillation', None))
+        return np.array(_scintillation, dtype=object)
+
+    @scintillation.setter
+    def scintillation(self, val):
+        for src in self.src:
+            src.scintillation = val[src.ast_idx]
+
+    @property
+    def scintillation_no_pupil(self):
+        _scintillation_no_pupil = []
+        for src in self.src:
+            _scintillation_no_pupil.append(getattr(src, 'scintillation_no_pupil', None))
+        return np.array(_scintillation_no_pupil, dtype=object)
 
     def __pow__(self, obj):
         # Re-propagation function. Same as .* in OOMAO

--- a/OOPAO/Atmosphere.py
+++ b/OOPAO/Atmosphere.py
@@ -36,7 +36,12 @@ class Atmosphere:
                  src=None,
                  param=None,
                  elevation: float = 90.0, 
-                 mode: float = 2):
+                 mode: float = 2,
+                 angular_spectrum_propagation: bool = False,
+                 geometric_phase_backup: bool = False,
+                 unwrap_diffractive_phase = False,
+                 rytov_var: float = None, 
+                 rytov_wvl: float = 500e-9):
         """ ATMOSPHERE.
         An Atmosphere is made of one or several layer of turbulence that follow the Van Karmann statistics.
         Each layer is considered to be independant to the other ones and has its own properties (direction, speed, etc.)
@@ -45,8 +50,11 @@ class Atmosphere:
         If the source type is an LGS the cone effect is considered using an interpolation.
         NGS and LGS can be combined together in the Asterism object.
         The convention chosen is that all the wavelength-dependant atmosphere parameters are expressed at 500 nm.
-
         The atmosphere is computaded at the elevation defined by the user (by default at zenith) and can be updated on the fly by changing the atm.elevation value.
+        The atmosphere has three propagation modes :
+            1 : geometric propagation only (no scintillation, no diffractive effects) -> atm.angular_spectrum_propagation = False and atm.geometric_phase_backup = False
+            2 : diffractive propagation with scintillation -> atm.angular_spectrum_propagation = True and atm.geometric_phase_backup = False
+            3 : diffractive propagation with scintillation and geometric phase backup -> atm.angular_spectrum_propagation = True and atm.geometric_phase_backup = True
         Parameters
         ----------
         telescope : Telescope
@@ -78,6 +86,17 @@ class Atmosphere:
         elevation : float, optional 
             Elevation of the site in degrees. This is used to compute the effective r0 and the altitude of the layers in zenith.
             The default is 90 deg (i.e. zenith).
+        angular_spectrum_propagation : bool, optional
+            If True, the scintillation is computed using a diffractive propagation of the wavefront through the layers. If False, only the geometric phase is computed.
+            The default is False.
+        geometric_phase_backup : bool, optional
+            If True, the geometric phase is kept as a backup and can be used to compare the effect of the scintillation on the final phase.
+            The default is False.
+        rytov_var : float, optional
+            If not None, the variance of the Rytov fluctuations is set to this value. This allows to simulate specific scintillation conditions.
+            The default is None, in which case the Rytov variance is computed from the Cn2 profile and the wavelength using the formula from Tatarskii (1961).
+        rytov_wvl : float, optional
+            Wavelength at which the Rytov variance is computed in [m]. The default is 500 nm.
 
         Raises
         ------
@@ -110,6 +129,8 @@ class Atmosphere:
         _ atm.seeingArcsec                          : seeing in arcsec at 500 nm
         _ atm.layer_X                               : access the child object corresponding to the layer X where X starts at 0
         _ atm.elevation                             : elevation of the site in degrees. This is used to compute the effective r0 and the altitude of the layers in zenith.
+        _ atm.angular_spectrum_propagation          : if True, the propagation is computed using a diffractive propagation of the wavefront through the layers. If False, only the geometric phase is computed.
+        _ atm.geometric_phase_backup                : if True, the geometric phase is kept as a backup and can be used to compare the effect of the scintillation on the final phase.
 
         The main properties of the object can be displayed using :
             atm.print_properties()
@@ -146,13 +167,15 @@ class Atmosphere:
         else:
             self.precision_complex = xp.complex128
         self.hasNotBeenInitialized = True
-        # Wavelengt used to define the properties of the atmosphere
-        self.wavelength = 500*1e-9
+        # Elevation initialization
         self.__updating_r0 = False # Protection to go faster when the r0 is updated without re-generating the phase screens
+        self.angular_spectrum_propagation = angular_spectrum_propagation
+        self.geometric_phase_backup = geometric_phase_backup
         self.altitude = altitude # altitude of the atmospheric layers
         self.wavelength = 500*1e-9 # Wavelengt used to define the properties of the atmosphere
         self._elevation = max(5.0, float(elevation))
         el_rad = np.radians(self._elevation)
+        self.sampling_checked = False
         self.altitude_zenith = [h * np.sin(el_rad) for h in self.altitude]
         self.r0_def = 0.15  # Default Fried Parameter in m at 500 nm to build covariance matrices once and scale them later
         self.r0 = r0  # User input Fried Parameter in m at 500 nm
@@ -186,7 +209,13 @@ class Atmosphere:
             self.src_list = self.src.src
             self.asterism = self.src
         self.param = param
-
+        #♥ Rytov initialization
+        self.rytov_wvl = float(rytov_wvl)
+        self.update_rytov_variance()
+        if rytov_var is not None:
+            self.update_rytov_variance()
+            self.rytov_var = float(rytov_var)
+        
     def initializeAtmosphere(self, telescope=None, compute_covariance=True):
         if telescope is not None:
             self.telescope = telescope
@@ -456,23 +485,43 @@ class Atmosphere:
             self.asterism = src
         if self.is_user_defined_opd:
             OPD_support = [self.user_defined_opd]*len(self.src_list)
-            warning('User-Defined OPD are only propagated once in the Atmosphere class. Consider using the OPD_map class.')
-        else:
-            # compute the pupil footprint for each layers and each source
-            self.set_pupil_footprint()
-            for src in self.src_list:
-                if src.coordinates[0] > self.fov/2:
-                    raise OopaoError('The source object zenith ('+str(src.coordinates[0])+'") is outside of the telescope fov ('+str(
-                        self.fov//2)+'")! You can:\n - Reduce the zenith of the source \n - Re-initialize the atmosphere object using a telescope with a larger fov')
-                src.through_atm = True
-                src.optical_path.append([self.tag, self])
-            # intialize the OPD support
-            OPD_support = self.initialize_OPD_support()
-            # fill the support for each layer
+            warning('User-Defined OPD are only propagated once in the Atmosphere class.')
+            self.set_OPD(OPD_support)
+            self.is_user_defined_opd = False
+            return
+        # compute the pupil footprint
+        self.set_pupil_footprint()
+        for src in self.src_list:
+            if src.coordinates[0] > self.fov/2:
+                raise OopaoError(f'Source zenith ({src.coordinates[0]}") outside of fov!')
+            src.through_atm = True
+            src.optical_path.append([self.tag, self])
+        # geometric baseline
+        needs_geometric = (not getattr(self, 'angular_spectrum_propagation', False)) or \
+                          getattr(self, 'geometric_phase_backup', False) or \
+                          getattr(self, 'unwrap_diffractive_phase', False)
+        OPD_support = self.initialize_OPD_support()
+        if needs_geometric:
             for i_layer in range(self.nLayer):
                 tmp_layer = getattr(self, 'layer_' + str(i_layer + 1))
                 OPD_support = self.fill_OPD_support(tmp_layer, OPD_support, i_layer)
-        self.set_OPD(OPD_support)
+        # diffractive propagation
+        if getattr(self, 'angular_spectrum_propagation', False):
+            self.check_fresnel_sampling()
+            # sort layers by altitude (top to bottom)
+            layers_data = [{'layer': getattr(self, 'layer_'+str(i+1)), 'idx': i, 'alt': getattr(self, 'layer_'+str(i+1)).altitude} for i in range(self.nLayer)]
+            layers_sorted = sorted(layers_data, key=lambda x: x['alt'], reverse=True)
+            scintillation_support = self.initialize_scintillation_support()
+            for k, item in enumerate(layers_sorted):
+                dist = item['alt'] - layers_sorted[k+1]['alt'] if k < len(layers_sorted)-1 else item['alt']
+                scintillation_support = self.fill_scintillation_support(item['layer'], scintillation_support, dist, item['idx'])
+            # extract maps and apply setters
+            self.set_scintillation_support(scintillation_support, OPD_support)
+        else:
+            # apply standard geometric maps if scintillation is disabled
+            intensity_support = [xp.ones((self.telescope.resolution, self.telescope.resolution), dtype=self.precision()) for _ in self.src_list]
+            self.set_scintillation(intensity_support)
+            self.set_OPD(OPD_support)
         self.is_user_defined_opd = False
         return
 
@@ -522,6 +571,79 @@ class Atmosphere:
             src.OPD_no_pupil = OPD_support[i]
             src.OPD = src.OPD_no_pupil*src.mask
         self.OPD = np.squeeze(np.array(OPD_support))
+        return
+    
+    def set_scintillation(self, scintillation_support): 
+        for i, src in enumerate(self.src_list):
+            src.scintillation_no_pupil = scintillation_support[i]
+            src.scintillation = src.scintillation_no_pupil*src.mask
+        self.scintillation_map = xp.squeeze(xp.array(scintillation_support))
+        return
+    
+    def initialize_scintillation_support(self):
+        scintillation_support = []
+        for i in range(len(self.src_list)):
+            scintillation_support.append(xp.ones([self.telescope.resolution, self.telescope.resolution], dtype=self.precision_complex))
+        return scintillation_support
+
+    def fill_scintillation_support(self, tmp_layer, scintillation_support, distance, i_layer):
+        n_pix = self.telescope.resolution
+        pxl_scale = getattr(self.telescope, 'pixelSize', self.telescope.D / self.telescope.resolution)
+        # extract the geometric OPD for this layer only
+        temp_zeros = [xp.zeros((n_pix, n_pix), dtype=self.precision()) for _ in range(len(self.src_list))]
+        layer_opd = self.fill_OPD_support(tmp_layer, temp_zeros, i_layer)
+        for i_src, src in enumerate(self.src_list):
+            wvl = src.wavelength
+            # apply phase screen
+            phi = layer_opd[i_src] * (2 * xp.pi / wvl)
+            scintillation_support[i_src] = scintillation_support[i_src] * xp.exp(1j * phi)
+            # propagate using angular spectrum
+            if distance > 1e-6:
+                scintillation_support[i_src] = self.ASM(
+                    scintillation_support[i_src], wvl, pxl_scale, pxl_scale, distance)
+        return scintillation_support
+
+    def set_scintillation_support(self, scintillation_support, OPD_support):
+        intensity_support = []
+        for i, src in enumerate(self.src_list):
+            E_field = scintillation_support[i]
+            wvl = src.wavelength
+            # Extract intensity
+            intensity = xp.abs(E_field)**2
+            intensity_support.append(intensity)
+            # --- Phase Extraction Routing ---
+            if getattr(self, 'geometric_phase_backup', False):
+                # Case 1: Pure geometric OPD (OPD_support is already populated)
+                pass 
+            elif getattr(self, 'unwrap_diffractive_phase', False):
+                # Case 2: Hybrid geometric guide + diffractive perturbation
+                # Convert geometric OPD to phase [rad]
+                phi_geo = OPD_support[i] * (2 * xp.pi / wvl)
+                
+                # Extract the wrapped diffractive residual (delta)
+                delta = xp.angle(E_field * xp.exp(-1j * phi_geo))
+                
+                # Safety check: warn if the residual itself wraps inside the pupil
+                pupil_mask = self.telescope.pupil > 0 # Ensure boolean masking
+                delta_pupil = delta[pupil_mask]
+                
+                if delta_pupil.size > 0: # Safeguard
+                    min_delta = xp.min(delta_pupil)
+                    max_delta = xp.max(delta_pupil)
+                    C = max_delta - min_delta
+                    if C > 1.9 * xp.pi: 
+                        warning(f"Diffractive residual wrapped inside the pupil! (C = {C:.2f} rad). Scintillation is too strong for perfect unwrapping.")
+                
+                # Combine guide and residual, then convert back to OPD [m]
+                final_phase = phi_geo + delta
+                OPD_support[i] = final_phase * (wvl / (2 * xp.pi))
+            else:
+                # Case 3: Standard ASM phase 
+                final_phase = xp.angle(E_field)
+                OPD_support[i] = final_phase * (wvl / (2 * xp.pi))
+        # Route to the final setters
+        self.set_scintillation(intensity_support)
+        self.set_OPD(OPD_support)
         return
 
     def get_covariance_matrices(self, layer):
@@ -732,12 +854,103 @@ class Atmosphere:
             ax.legend(loc='upper left')
             makeSquareAxes(plt.gca())
 
+    def update_rytov_variance(self):
+        if not hasattr(self, 'nLayer') or not hasattr(self, '_fractionalR0') or not hasattr(self, 'altitude'):
+            return
+        if not hasattr(self, 'rytov_wvl'):
+            self.rytov_wvl = 500e-9    
+        k_target = 2 * xp.pi / self.rytov_wvl
+        r0_target_wvl = self.r0 * (self.rytov_wvl / self.wavelength)**(6/5)
+        total_cn2_integral = (r0_target_wvl**(-5/3)) / (0.423 * k_target**2)
+        current_rytov = 0.0
+        for i in range(self.nLayer):
+            if self.altitude[i] > 1e-3: 
+                current_rytov += (total_cn2_integral * self.fractionalR0[i]) * (self.altitude[i]**(5/6))
+        self._rytov_var = current_rytov * 2.2524 * (k_target**(7/6))
+        if getattr(self, 'angular_spectrum_propagation', False):
+            if self._rytov_var > 0.3 and not getattr(self, '_saturation_warned', False):
+                warning(f"Atmospheric conditions degraded. Rytov variance ({self._rytov_var:.2f}) exceeds 0.3 limit! "
+                        "Entering saturation regime.")
+                self._saturation_warned = True 
+            elif self._rytov_var <= 0.3:
+                self._saturation_warned = False 
+
+    def ASM(self, input_field, wavelength, input_pitch, output_pitch, distance):
+        if distance == 0:
+            return input_field  
+        N = input_field.shape[0]
+        k = 2 * xp.pi / wavelength
+        # spatial frequency grids
+        delta_f = 1.0 / (N * input_pitch)
+        vals = xp.arange(-N/2, N/2, dtype=input_field.real.dtype) * delta_f
+        fx, fy = xp.meshgrid(vals, vals, copy=False)
+        f_sq = fx**2 + fy**2
+        # spatial grids
+        vals_r = xp.arange(-N/2, N/2, dtype=input_field.real.dtype) * input_pitch
+        x, y = xp.meshgrid(vals_r, vals_r, copy=False)
+        r_sq = x**2 + y**2
+        m = output_pitch / input_pitch
+        # input chirp
+        if m != 1.0:
+            phase_1 = xp.exp(1j * k/2 * (1-m)/distance * r_sq)
+        else:
+            phase_1 = 1.0  
+        # transfer kernel
+        phase_2 = xp.exp(-1j * xp.pi * wavelength * distance / m * f_sq)
+        # output chirp
+        if m != 1.0:
+            vals_out = xp.arange(-N/2, N/2, dtype=input_field.real.dtype) * output_pitch
+            x_out, y_out = xp.meshgrid(vals_out, vals_out, copy=False)
+            r_out_sq = x_out**2 + y_out**2
+            phase_3 = xp.exp(1j * k/2 * (m-1)/(m*distance) * r_out_sq)
+        else:
+            phase_3 = 1.0
+        # fft operations
+        field_freq = xp.fft.fft2(xp.fft.ifftshift(input_field * phase_1))
+        field_filtered = xp.fft.ifftshift(xp.fft.fftshift(field_freq) * phase_2)
+        field_out = xp.fft.fftshift(xp.fft.ifft2(field_filtered))
+        return field_out * phase_3 / m
+    
+    def check_fresnel_sampling(self):
+        """
+        Internal verification of the telescope grid for Fresnel propagation.
+        Issues warnings if the grid is prone to aliasing or violates ASM limits.
+        """
+        if not getattr(self, 'scintillation', False) or getattr(self, 'sampling_checked', False):
+            return
+        D_tel_phys = getattr(self.telescope, 'initial_D', self.telescope.D)
+        N_current = self.telescope.resolution
+        delta = getattr(self.telescope, 'pixelSize', self.telescope.D / N_current)
+        alts = sorted(self.altitude + [0.0], reverse=True)
+        max_step = max([alts[i] - alts[i+1] for i in range(len(alts)-1)]) if len(alts) > 1 else 0
+        z_max = max(self.altitude) if self.altitude else 0
+        for src in self.src_list:
+            wvl = src.wavelength
+            r0_wvl = self._r0 * (wvl / self.wavelength)**(6/5)
+            # Coy's spread (bilateral support)
+            D_turb = 4.0 * (wvl * z_max) / r0_wvl
+            D_total = D_tel_phys + 2.0 * D_turb
+            delta_req = min(r0_wvl / 4.0, (wvl * z_max) / D_total)
+            # Strict ASM anti-aliasing (N >= D_tot/delta + lambda*z/delta^2)
+            N_min_physique = (D_total / delta) + (wvl * z_max) / (delta**2)
+            z_asm = (N_current * delta**2) / wvl
+            if delta > delta_req:
+                warning(f"Fresnel [wvl={wvl*1e9:.0f}nm] - Pixel scale ({delta*1000:.1f} mm) too large! Limit is {delta_req*1000:.1f} mm.")
+            if N_current < N_min_physique:
+                N_min_int = int(np.ceil(N_min_physique))
+                warning(f"Fresnel Aliasing [wvl={wvl*1e9:.0f}nm] - Grid N={N_current} too small (Physics requires N >= {N_min_int}).")
+                warning(f"-> Action required: Pad your telescope to the next multiple of your WFS res_factor >= {N_min_int}.")
+            if max_step > z_asm:
+                warning(f"Fresnel ASM Limit [wvl={wvl*1e9:.0f}nm] - Distance between layers ({max_step/1000:.1f} km) > limit ({z_asm/1000:.1f} km).")
+        self.sampling_checked = True
+
     @property
     def r0(self):
         return self._r0
 
     @r0.setter
     def r0(self, val):
+        self.sampling_checked = False
         self._r0 = val
         el_rad = np.radians(self.elevation) 
         self.r0_zenith = val * (np.sin(el_rad))**(-3/5)  # r0 at zenith
@@ -754,6 +967,7 @@ class Atmosphere:
                     tmp_layer.ZZt_inv_r0 = tmp_layer.ZZt_inv / ((self.r0_def/self.r0)**(5/3))
                     BBt = tmp_layer.XXt_r0 - xp.matmul(tmp_layer.A, tmp_layer.ZXt_r0)
                     tmp_layer.B = xp.linalg.cholesky(BBt).astype(self.precision())
+        self.update_rytov_variance()
 
     @property
     def L0(self):
@@ -836,6 +1050,7 @@ class Atmosphere:
                 print('Updating the fractional R0...BEWARE COMPLETE THE RECOMPUTATION...NOT ONLY V0 and Tau0 !')
                 self.V0 = (np.sum(np.asarray(self.fractionalR0) * np.asarray(self.windSpeed))**(5/3))**(3/5)  # computation of equivalent wind speed, Roddier 1982
                 self.tau0 = 0.31 * self.r0 / self.V0  # Coherence time of atmosphere, Roddier 1981
+        self.update_rytov_variance()
 
     @property
     def elevation(self):
@@ -843,7 +1058,7 @@ class Atmosphere:
 
     @elevation.setter
     def elevation(self, val):
-     
+        self.sampling_checked = True
         val = float(val)
         if val < 5.0: 
             warning("Very low elevation (< 5 deg). Clamping to 5 deg.")
@@ -863,8 +1078,55 @@ class Atmosphere:
                 self.initializeAtmosphere(self.telescope, compute_covariance=self.compute_covariance)
             else:
                 raise OopaoError("Warning: Atmosphere not yet linked to a telescope. Call initializeAtmosphere() manually.")
-        
+        self.update_rytov_variance()
     
+    @property
+    def rytov_var(self):
+        if not getattr(self, 'angular_spectrum_propagation', False):
+            return 0.0
+        if not hasattr(self, '_rytov_var'):
+            self.update_rytov_variance()
+        return self._rytov_var
+
+    @rytov_var.setter
+    def rytov_var(self, val):
+        if not getattr(self, 'angular_spectrum_propagation', False):
+            warning("Cannot set Rytov variance because atm.angular_spectrum_propagation is False.")
+            return    
+        val = float(val)
+        if val <= 0:
+            return 
+        saturation_threshold = 0.3
+        if val > saturation_threshold:
+            warning(f"Target Rytov variance ({val:.2f}) exceeds the weak fluctuation limit ({saturation_threshold}). "
+                    "The simulation is entering the moderate/strong scintillation regime (saturation). "
+                    "Phase unwrapping and scaling behaviors may become unstable.")
+        self.update_rytov_variance()
+        current = self._rytov_var
+        if current > 0:
+            ratio = val / current
+            print(f"--- Scaling Rytov variance to {val:.4f} (Ratio: {ratio:.3f}) ---")
+            new_r0 = self.r0 * (ratio**(-3/5))
+            self.r0 = new_r0 
+            scale_factor = float(np.sqrt(ratio))
+            
+            for i in range(1, getattr(self, 'nLayer', 3) + 1):
+                layer_name = f'layer_{i}'
+                if hasattr(self, layer_name):
+                    layer_obj = getattr(self, layer_name)
+                    if hasattr(layer_obj, 'OPD') and layer_obj.OPD is not None:
+                        layer_obj.OPD *= scale_factor
+            self.update_rytov_variance()
+        else:
+            warning("Cannot scale Rytov (all layers are at 0m).")
+        
+        if getattr(self, 'angular_spectrum_propagation', False):
+            if self._rytov_var > 0.3 and not getattr(self, '_saturation_warned', False):
+                warning(f"Atmospheric conditions degraded. Rytov variance ({self._rytov_var:.2f}) exceeds 0.3 limit! "
+                        "Entering saturation regime.")
+                self._saturation_warned = True 
+            elif self._rytov_var <= 0.3:
+                self._saturation_warned = False
 
     # for backward compatibility
     def print_properties(self):

--- a/OOPAO/BioEdge.py
+++ b/OOPAO/BioEdge.py
@@ -560,7 +560,7 @@ class BioEdge:
         if phase_in is not None:
             self.src.phase = phase_in
         # mask amplitude for the light propagation
-        self.maskAmplitude = self.convert_for_gpu(np.sqrt(self.src.fluxMap/self.nTheta)*self.telescope.pupilReflectivity)
+        self.maskAmplitude = self.convert_for_gpu(np.sqrt((self.src.fluxMap * self.src.scintillation)/self.nTheta))
 
         if self.spatialFilter is not None:
             if np.ndim(phase_in) == 2:

--- a/OOPAO/Pyramid.py
+++ b/OOPAO/Pyramid.py
@@ -285,7 +285,7 @@ class Pyramid:
         self.cam = Detector(round(nSubap*self.zeroPaddingFactor))
         # WFS focal plane detector object (see Detector class)
         self.focal_plane_camera = Detector(int(
-            (modulation*4+12)*self.zeroPaddingFactor), psf_sampling=self.zeroPaddingFactor)
+            (modulation*4+12)*self.zeroPaddingFactor*self.telescope.resolution/self.telescope.initial_resolution), psf_sampling=self.zeroPaddingFactor*self.telescope.resolution/self.telescope.initial_resolution)
         self.focal_plane_camera.is_focal_plane_camera = True
         # Light ratio for the valid pixels selection
         self.lightRatio = lightRatio
@@ -666,7 +666,7 @@ class Pyramid:
         if phase_in is not None:
             self.src.phase = phase_in
         # mask amplitude for the light propagation
-        self.maskAmplitude = self.convert_for_gpu(np.sqrt(self.src.fluxMap/self.nTheta))
+        self.maskAmplitude = self.convert_for_gpu(np.sqrt((self.src.fluxMap * self.src.scintillation)/self.nTheta))
 
         if self.spatialFilter is not None:
             if np.ndim(phase_in) == 2:

--- a/OOPAO/ShackHartmann.py
+++ b/OOPAO/ShackHartmann.py
@@ -708,17 +708,21 @@ class ShackHartmann:
         centroid_out[:, 0] = np.sum(np.sum(im*X_coord_map, axis=1), axis=1)/norma
         centroid_out[:, 1] = np.sum(np.sum(im*Y_coord_map, axis=1), axis=1)/norma
         return centroid_out
-
+    
     def get_lenslet_em_field(self, src, sh_data, phase):
         tmp_phase_h_split = np.hsplit(phase.T, self.nSubap)
+        tmp_amp_h_split = np.hsplit(np.sqrt(src.scintillation.T), self.nSubap)
         self.cube_em = np.zeros([self.nSubap**2,
                                  self.n_pix_lenslet_init,
                                  self.n_pix_lenslet_init], dtype=complex)
         for i in range(self.nSubap):
             tmp_phase_v_split = np.vsplit(tmp_phase_h_split[i], self.nSubap)
+            tmp_amp_v_split = np.vsplit(tmp_amp_h_split[i], self.nSubap)
+            # compute complex field with both amplitude and phase
+            complex_field = np.asarray(tmp_amp_v_split) * np.exp(1j*np.asarray(tmp_phase_v_split)) 
             self.cube_em[i*self.nSubap:(i+1)*self.nSubap,
                          self.center_init - self.n_pix_subap_init//2:self.center_init+self.n_pix_subap_init//2,
-                         self.center_init - self.n_pix_subap_init//2:self.center_init+self.n_pix_subap_init//2] = np.exp(1j*np.asarray(tmp_phase_v_split))
+                         self.center_init - self.n_pix_subap_init//2:self.center_init+self.n_pix_subap_init//2] = complex_field           
         self.cube_em *= np.sqrt(sh_data.cube_flux)*self.phasor_tiled
         return self.cube_em
 

--- a/OOPAO/Source.py
+++ b/OOPAO/Source.py
@@ -70,6 +70,7 @@ class Source:
         The main properties of a Source object are listed here:
         _ src.phase     : 2D map of the phase scaled to the src wavelength corresponding to tel.OPD
         _ src.type      : Ngs or LGS
+        _ src.scintillation : 2D map of the scintillation pattern corresponding to tel.OPD
 
         _ src.nPhoton   : number of photons per m2 per s. if this property is changed after the initialization, the magnitude is automatically updated to the right value.
         _ src.fluxMap   : 2D map of the number of photons per pixel per frame (depends on the loop frequency defined by tel.samplingTime)
@@ -147,6 +148,10 @@ class Source:
         self._OPD_no_pupil = None
         self.phase_filtered = None
         self.amplitude_filtered = None
+        # Variables for scintillation
+        self.var_chi = None
+        self.var_rytov = None
+        self.scintillation = None
         # mask to compute the OPD with pupil.
         # Initally set to 1 so it doesnt do anything until the source is propagated through the telescope.
         self.mask = 1
@@ -181,6 +186,10 @@ class Source:
         self.OPD_no_pupil = None
         self.phase_filtered = None
         self.amplitude_filtered = None
+        self.scintillation = None
+        self.scintillation_no_pupil = None
+        self.var_chi = None
+        self.var_rytov = None
 
     def print_optical_path(self):
         if self.optical_path is not None:
@@ -199,7 +208,7 @@ class Source:
     def OPD(self, val):
         if val is not None:
             self._OPD = np.array(val)
-            self._OPD_no_pupil = np.array(val)
+            # self._OPD_no_pupil = np.array(val)
         else:
             self._OPD = None
             self._OPD_no_pupil = None
@@ -235,6 +244,36 @@ class Source:
     @phase_no_pupil.setter
     def phase_no_pupil(self, val):
         self.OPD_no_pupil = (val * self.wavelength) / (2 * np.pi)
+
+
+    @property
+    def scintillation(self):
+        return self._scintillation
+
+    @scintillation.setter
+    def scintillation(self, val):
+        if val is not None:
+            self._scintillation = np.array(val)
+            # self._scintillation_no_pupil = np.array(val)
+        else:
+            self._scintillation = None
+            self._scintillation_no_pupil = None
+            
+    @property
+    def scintillation_no_pupil(self):
+        return self._scintillation_no_pupil
+
+    @scintillation_no_pupil.setter
+    def scintillation_no_pupil(self, val):
+        if val is not None:
+            self._scintillation_no_pupil = np.array(val)
+            if len(val.shape) > 2 and np.isscalar(self.mask) is False:
+                self.scintillation = self._scintillation_no_pupil * self.mask[:, :, np.newaxis]
+            else:
+                self.scintillation = self._scintillation_no_pupil * self.mask
+        else:
+            self._scintillation_no_pupil = None
+
 
     def photometry(self, arg):
         # photometry object [wavelength, bandwidth, zeroPoint]
@@ -355,6 +394,69 @@ class Source:
         self._nPhoton = self.zeroPoint*10**(-0.4*self._magnitude)
         print('Flux updated, magnitude is %2i and flux is %.2e' % (self._magnitude, self._nPhoton))
         self.__updating_flux = False
+    
+    @property
+    def rytov_variance(self):
+        """
+        Computes the Rytov variance on the fly.
+        """
+        from .tools.tools import compute_rytov_variance
+        return compute_rytov_variance(self.scintillation, self.tel.pupil)
+
+    def get_dsp(self, telescope):
+        """
+        Computes the 1D PSDs (azimuthally averaged) for phase and log-amplitude.
+        Parameters
+        ----------
+        telescope : Telescope
+            The telescope object used to retrieve resolution and pixel size.
+        """
+        from .tools.tools import compute_dsp
+        return compute_dsp(
+            phase=self.phase_no_pupil,
+            scintillation=self.scintillation_no_pupil,
+            resolution=telescope.resolution,
+            pixel_size=telescope.pixelSize, 
+        )
+
+    def get_theoretical_pupil_variance(self, D_tel, L_source, L0, Cn2_input):
+        """
+        Computes the theoretical pupil-averaged log-amplitude variance.
+        Automatically uses the source's wavelength.
+        """
+        from .tools.tools import compute_theoretical_pupil_log_amp_variance
+        return compute_theoretical_pupil_log_amp_variance(
+            wavelength=self.wavelength,
+            D_tel=D_tel,
+            L_source=L_source,
+            L0=L0,
+            Cn2_input=Cn2_input
+        )
+    
+    def get_theoretical_rytov(self, atm):
+        """
+        Computes the theoretical Rytov variance based on atmospheric parameters.
+        """
+        from .tools.tools import compute_theoretical_rytov
+        return compute_theoretical_rytov(
+            wavelength=self.wavelength,
+            r0=atm.r0,
+            altitudes=atm.altitude,
+            fractionalR0=atm.fractionalR0
+        )
+    
+    def get_theoretical_dsp(self, kappa, r0, L0, altitude):
+        """
+        Retrieves the theoretical PSDs for the current source wavelength.
+        """
+        from .tools.tools import compute_theoretical_psd
+        return compute_theoretical_psd(
+            kappa=kappa,
+            wavelength=self.wavelength,
+            r0=r0,
+            L0=L0,
+            altitude=altitude
+        )
 
     # for backward compatibility
     def print_properties(self):

--- a/OOPAO/Telescope.py
+++ b/OOPAO/Telescope.py
@@ -212,6 +212,13 @@ class Telescope:
                 src.OPD = (src.OPD_no_pupil)*src.mask
             else:
                 src.OPD_no_pupil = np.zeros(self.pupil.shape)
+            if getattr(src, 'scintillation', None) is None:
+                src.scintillation_no_pupil = np.ones(self.pupil.shape)
+                src.scintillation = (src.scintillation_no_pupil)*src.mask
+            elif np.ndim(src.scintillation) == 2:
+                src.scintillation = (src.scintillation_no_pupil)*src.mask
+            else:
+                src.scintillation_no_pupil = np.ones(self.pupil.shape)
             src.var = np.var(src.phase[np.where(self.pupil == 1)])
             src.fluxMap = self.pupilReflectivity * src.nPhoton * self.samplingTime * (self.D / self.resolution) ** 2
         return
@@ -304,6 +311,7 @@ class Telescope:
             else:
                 amp_mask = input_source[i_src].amplitude_filtered
                 phase = input_source[i_src].phase_filtered
+            amp_mask = amp_mask * xp.sqrt(input_source[i_src].scintillation)
             # amplitude of the EM field:
             amp = amp_mask*self.pupil*self.pupilReflectivity
             # add a Tip/Tilt for off-axis sources

--- a/OOPAO/tools/tools.py
+++ b/OOPAO/tools/tools.py
@@ -15,6 +15,10 @@ import skimage.transform as sk
 from astropy.io import fits as pfits
 from OOPAO.tools import *
 import matplotlib.pyplot as plt
+from scipy.integrate import quad
+from scipy.special import j1
+from scipy.signal.windows import tukey
+import math
 
 
 #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% USEFUL FUNCTIONS %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -550,3 +554,169 @@ class OopaoError(Exception):
         self.string = string
         self.message = (string)
         super().__init__(self.message)
+
+
+# Scintillation specific tools
+def radial_profile(data, max_radius):
+    """
+    Computes the azimuthal average of a 2D array to yield a 1D profile.
+    """
+    y, x = np.indices(data.shape)
+    center = np.array(data.shape) / 2
+    r = np.sqrt((x - center[1])**2 + (y - center[0])**2)
+    r = r.astype(int)
+    tbin = np.bincount(r.ravel(), data.ravel())
+    nr = np.bincount(r.ravel())
+    radialprofile = tbin / np.maximum(nr, 1)
+    return radialprofile[:max_radius]
+
+def compute_rytov_variance(scintillation, pupil):
+    """
+    Computes the Rytov variance from scintillation data and pupil mask.
+    """
+    if scintillation is None:
+        return 0.0
+    mask = pupil > 0
+    I = scintillation[mask]
+    I = I[I > 1e-10]
+    I = I / np.mean(I)
+    chi = 0.5 * np.log(I)
+    var_chi = np.var(chi)
+    return 4.0 * var_chi
+
+
+def compute_theoretical_pupil_log_amp_variance(wavelength, D_tel, L_source, L0, Cn2_input):
+    """
+    Computes the pupil-averaged log-amplitude variance theoretically (Eq 3.43).
+    """
+    k0 = 2 * np.pi / wavelength
+    R_tel = D_tel / 2.0
+    K_piston = (R_tel**(5/3)) * (k0**2) 
+    def integrand_k(k, z):
+        if k < 1e-9: return 0
+        von_karman = (1 + ((2 * np.pi * R_tel) / (L0 * k))**2)**(-11/6)
+        diffraction = (j1(k))**2
+        propagation = np.sin((z * k**2) / (2 * k0 * R_tel**2))**2
+        power_law = k**(-14/3)
+        return power_law * diffraction * propagation * von_karman
+    def integrand_z(z):
+        val_cn2 = Cn2_input(z) if callable(Cn2_input) else Cn2_input
+        res_k, _ = quad(integrand_k, 0, 200, args=(z,), limit=100)
+        return val_cn2 * res_k
+    integral_z_val, _ = quad(integrand_z, 0, L_source)
+    variance_ap = 5.20 * K_piston * integral_z_val
+    return variance_ap 
+
+def compute_theoretical_rytov(wavelength, r0, altitudes, fractionalR0):
+    """
+    Computes the theoretical Rytov variance for a layered atmosphere.
+    
+    Parameters
+    ----------
+    wavelength : float [m]
+    r0 : float [m]
+    altitudes : array [m]
+    fractionalR0 : array (fractions de r0 par couche)
+    """
+    k0 = 2 * np.pi / wavelength
+    altitudes = np.array(altitudes)
+    fractionalR0 = np.array(fractionalR0)
+    # Conversion fractions r0 -> fractions Cn2
+    weights = fractionalR0**(5/3)
+    weights /= np.sum(weights)
+    # Cn2 integral factor (constant for a given r0 and wavelength)
+    Cn2_integral = (r0**(-5/3)) / (0.423 * k0**2)
+    # discrete summation over layers
+    sigma_R2 = 0
+    for i in range(len(altitudes)):
+        z = altitudes[i]
+        sigma_R2 += weights[i] * (z**(5/6))
+    sigma_R2 *= Cn2_integral
+    sigma_R2 *= 2.25 * (k0**(7/6))
+    return sigma_R2
+
+
+def compute_dsp(phase, scintillation, resolution, pixel_size):
+    """
+    Computes phase and scintillation PSD using a Tukey window to prevent spectral leakage.
+    Analyzes atmospheric statistics independently of the telescope pupil.
+    """
+    N = phase.shape[0]
+    # 2D Tukey windowing (alpha=0.2 keeps 80% of the center flat)
+    window_1d = tukey(N, alpha=0.2)
+    window_2d = np.outer(window_1d, window_1d)
+    # Convert intensity to log-amplitude (Chi)
+    center_slice = slice(N // 4, 3 * N // 4)
+    mean_I = np.mean(scintillation[center_slice, center_slice])
+    chi = 0.5 * np.log(scintillation / mean_I + 1e-12)
+    # Phase centering
+    phi = phase - np.mean(phase[center_slice, center_slice])
+    # Window application and weighted mean removal
+    chi_windowed = chi * window_2d
+    phi_windowed = phi * window_2d
+    chi_windowed -= np.sum(chi_windowed) / np.sum(window_2d) * window_2d
+    phi_windowed -= np.sum(phi_windowed) / np.sum(window_2d) * window_2d
+    # Fourier Transform and Power Normalization (w2 compensates window energy loss)
+    w2 = np.sum(window_2d**2) 
+    norm = (pixel_size**2) / w2
+    ft_chi = np.fft.fft2(chi_windowed)
+    dsp_chi_2d = np.fft.fftshift(np.abs(ft_chi)**2) * norm
+    ft_phi = np.fft.fft2(phi_windowed)
+    dsp_phi_2d = np.fft.fftshift(np.abs(ft_phi)**2) * norm
+    # Radial profiling and frequency axis
+    dsp_chi_1d = radial_profile(dsp_chi_2d, N // 2)
+    dsp_phi_1d = radial_profile(dsp_phi_2d, N // 2)
+    freqs = np.fft.fftshift(np.fft.fftfreq(N, pixel_size))
+    kappa = freqs[N // 2:]
+    return kappa, dsp_phi_1d, dsp_chi_1d
+
+def compute_theoretical_psd(kappa, wavelength, r0, L0, altitude):
+    k_wvl = 2 * np.pi / wavelength
+    # Standard von Karman Phase PSD (rad^2 . m^2)
+    # Factor is 0.0229 for a 3D Kolmogorov spectrum integrated into 1D radial PSD
+    psd_pure = 0.023 * (r0**(-5/3)) * (kappa**2 + (1/L0)**2)**(-11/6)
+    # Fresnel Filter Argument
+    fresnel_arg = (altitude * (2 * np.pi * kappa)**2) / (2 * k_wvl)
+    psd_phi = psd_pure * (np.cos(fresnel_arg)**2)
+    psd_chi = psd_pure * (np.sin(fresnel_arg)**2)
+    return psd_phi, psd_chi
+
+def compute_fresnel_padding(D_tel, resolution, wavelengths, z_max, r0_wvl_list, max_layer_step, res_factor=1):
+    """
+    Computes required padding for Fresnel propagation, quantized for WFS compatibility.
+    Uses strict ASM anti-aliasing criteria.
+    """
+    delta = D_tel / resolution
+    diagnostics = {}
+    for i, wvl in enumerate(wavelengths):
+        r0 = r0_wvl_list[i]
+        # Coy's spread 
+        D_turb = 4.0 * (wvl * z_max) / r0
+        D_total = D_tel + 2.0 * D_turb
+        delta_req = min(r0 / 4.0, (wvl * z_max) / D_total)
+        delta_status = "OK"
+        if delta > delta_req:
+            delta_status = f"WARNING: Pixel size ({delta*1000:.2f} mm) > Limit ({delta_req*1000:.2f} mm)."
+        # Strict ASM anti-aliasing
+        N_min_physique = (D_total / delta) + (wvl * z_max) / (delta**2)
+        # Quantization (WFS constraint)
+        N_final = int(math.ceil(N_min_physique / res_factor) * res_factor)
+        if N_final < resolution:
+            N_final = int(math.ceil(resolution / res_factor) * res_factor)
+        pad_needed = (N_final - resolution) // 2 if N_final > resolution else 0
+        # ASM Longitudinal constraint
+        z_asm = (N_final * delta**2) / wvl
+        asm_status = "OK"
+        if max_layer_step > z_asm:
+            asm_status = f"WARNING: Max step ({max_layer_step/1000:.1f} km) > ASM limit ({z_asm/1000:.1f} km)."
+        diagnostics[f"{wvl*1e9:.0f}nm"] = {
+            "r0": r0,
+            "delta_req": delta_req,
+            "delta_status": delta_status,
+            "N_min_physique": int(math.ceil(N_min_physique)),
+            "N_quantized": N_final,
+            "padding_per_side_needed": pad_needed,
+            "z_asm_limit": z_asm,
+            "asm_status": asm_status
+        }
+    return diagnostics

--- a/tutorials/how_to_scintillation.py
+++ b/tutorials/how_to_scintillation.py
@@ -1,0 +1,926 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Thu Mar 26 16:04:55 2026
+
+@author: mpasinetti
+
+Tutorial Description — Scintillation in OOPAO
+
+This tutorial provides a focused walkthrough of modeling Scintillation in OOPAO, 
+illustrating an end-to-end setup to correctly configure and simulate amplitude fluctuations within a full optical chain.
+
+Starting from the initialization of a telescope and source, the script introduces the essential Fresnel padding checks required for accurate physical optics. 
+It explores atmospheric propagation in detail, showing how to switch between and compare the geometric and diffractive regimes.
+
+The tutorial highlights practical challenges and specific configurations needed for scintillation:
+    - applying the proper scaling of Deformable Mirrors on padded grids
+    - evaluating WFS behavior (both Pyramid and Shack-Hartmann)
+    - comparing optical responses with and without scintillation effects present in the beam.
+
+Finally, the simulation setup undergoes strict scientific validation, where users can analyze the Power Spectral Density (DSP) and verify the analytical scaling laws with respect to the target's elevation.
+
+"""
+
+
+import numpy as np
+import matplotlib.pyplot as plt
+
+from OOPAO.Atmosphere import Atmosphere
+from OOPAO.Detector import Detector
+from OOPAO.Pyramid import Pyramid
+from OOPAO.ShackHartmann import ShackHartmann
+import time
+from OOPAO.calibration.InteractionMatrix import InteractionMatrix
+from OOPAO.tools.displayTools import cl_plot, displayMap
+
+
+# =========================================================================
+# ----------------------- 0. SIMULATION PARAMETERS ------------------------
+# =========================================================================
+plt.ion()
+n_subaperture = 16
+res_factor = 8
+
+# %%-----------------------     TELESCOPE   ----------------------------------
+from OOPAO.Telescope import Telescope
+print("\n--- 1. Initializing Telescope & Sources ---")
+tel = Telescope(resolution           = res_factor * n_subaperture, 
+                diameter             = 0.6,                       
+                samplingTime         = 1/1000,                     
+                centralObstruction   = 0,                     
+                display_optical_path = False,                      
+                fov                  = 2 )           
+              
+plt.figure()
+plt.imshow(tel.pupil)
+plt.title("Non padded telescope")
+#%% -----------------------     NGS   ----------------------------------
+from OOPAO.Source import Source
+
+ngs = Source(optBand     = 'V', magnitude = 5, coordinates = [0,0])
+src = Source(optBand     = 'K',  magnitude = 5, coordinates = [1,0])
+
+#%% ------------------- FRESNEL PROPAGATION: PADDING VERIFICATION -------------------
+"""
+Since scintillation modeling relies on Fresnel propagation, grid padding must be 
+thoroughly validated to ensure a physically accurate optical propagation. 
+
+This cell demonstrates how to verify four essential sampling criteria against the 
+simulation's physical parameters. These criteria are extracted from the reference 
+book "Numerical Simulation of Optical Wave Propagation" by Jason D. Schmidt.
+"""
+print("\n--- 2. Verifying Fresnel Sampling Grid ---")
+from OOPAO.tools.tools import compute_fresnel_padding
+# Simulation parameter 
+elevation = 60  # elevation angle in deg
+airmass = 1.0 / np.sin(np.deg2rad(elevation)) # Airmass calculation (1 / sin(elevation)
+r0_500 = 0.06 # Zenith reference values
+altitudes = [0, 1000, 2000]
+wavelengths = [ngs.wavelength, src.wavelength]
+# Calculate r0 for each wavelength
+r0_wvl_list = [r0_500 * (wvl / 500e-9)**(6/5) for wvl in wavelengths]
+
+z_max = max(altitudes) if altitudes else 0
+alts_sorted = sorted(altitudes + [0.0], reverse=True)
+max_layer_step = max([alts_sorted[i] - alts_sorted[i+1] for i in range(len(alts_sorted)-1)]) if len(alts_sorted) > 1 else 0
+
+# Function to calculate the padding needed for the simulation
+diagnostics = compute_fresnel_padding(
+    D_tel=tel.D, resolution=tel.resolution, wavelengths=wavelengths,
+    z_max=z_max, r0_wvl_list=r0_wvl_list, max_layer_step=max_layer_step,
+    res_factor=res_factor 
+)
+max_N_required = max([diag['N_quantized'] for diag in diagnostics.values()])
+
+if max_N_required > tel.resolution:
+    # Calculate the total difference
+    diff = max_N_required - tel.resolution
+    
+    # Ensure the difference is even so the padding remains symmetric
+    if diff % 2 != 0:
+        diff += 1
+        
+    pad_val = diff // 2
+    print(f"=> Automatically padding the telescope by {pad_val} pixels per side...")
+    tel.pad(padding_values=pad_val)
+    tel.print_properties()
+    # Final safety check
+    if tel.resolution % 2 != 0:
+        print("Safety check: forcing even resolution")
+        tel.pad(padding_values=1) # Add 1 px to force an even number if needed
+else:
+    print("=> Grid is robust. No padding required.")
+
+# The padding must be done first as it will force the simualation grid size
+ngs ** tel
+src ** tel
+
+plt.figure()
+plt.imshow(tel.pupil)
+plt.title("Padded telescope")
+
+#%% ------------------- PROPAGATION REGIMES COMPARISON -------------------
+"""
+This section explores the 4 available propagation channels in OOPAO.
+
+1. Pure Geometric (No Scintillation)
+   - Physics: Ray optics approximation. The phase is purely integrated along 
+     the optical path. The amplitude remains uniform (flat intensity).
+   - Reality: Valid for near-field, large wavelengths, or observing at zenith.
+   - Limit: Ignores diffraction. Cannot model scintillation (speckles) or 
+     amplitude variations caused by deep turbulence or low-elevation targets.
+
+2. Full Diffractive (Wrapped Phase + Scintillation)
+   - Physics: Full wave optics via Fresnel propagation (Angular Spectrum Method). 
+     Properly models diffractive interference causing amplitude fluctuations.
+   - Reality: The exact physical electromagnetic field at the pupil plane.
+   - Limit: The phase is strictly bounded modulo 2π (wrapped). This makes it 
+     unusable for linear modal reconstructors or evaluating the macroscopic 
+     wavefront error without complex post-processing.
+
+3. Hybrid: Geometric Phase + Scintillation
+   - Physics: Mixes the physically propagated intensity (Fresnel) with the 
+     macroscopic geometric phase (Ray tracing). 
+   - Reality: Provides the macroscopic unwrapped phase for AO loop stability 
+     while retaining the intensity variations on the wavefront sensor.
+   - Limit: Ignores the high-frequency diffractive phase residuals (the tiny 
+     ripples on the wavefront). It's an approximation, though very efficient.
+
+4. Unwrapped Diffractive Phase + Scintillation
+   - Physics: Uses the geometric phase as a guide to 
+     perfectly unwrap the true diffractive phase. Contains BOTH the macroscopic 
+     turbulence and the diffractive residuals.
+   - Reality: The exact unwrapped physical phase.
+   - Limit: Computationally heavier. If the scintillation is extremely strong 
+     (e.g., extremely low elevation), the residual itself might wrap, breaking 
+     the unwrapping process.
+"""
+
+from OOPAO.Atmosphere import Atmosphere
+
+# create the Atmosphere object   
+atm = Atmosphere(telescope     = tel,                                          
+                 r0            = 0.05,                            
+                 L0            = 25,                                
+                 fractionalR0  = [0.45, 0.2, 0.35],                
+                 windSpeed     = [10   ,12   ,11],                
+                 windDirection = [0, 72, 288],             
+                 altitude      = altitudes, 
+                 elevation = 60)
+
+# --- EXTRACTING THE 4 CASES ---
+
+# CASE 1: Pure Geometric (No Scintillation)
+atm.angular_spectrum_propagation = False
+atm.initializeAtmosphere(tel)
+ngs ** atm * tel
+phase_geom = ngs.phase
+amp_geom = ngs.scintillation
+
+# CASE 2: Full scintillation and diffractive phase
+atm.angular_spectrum_propagation = True
+ngs ** atm * tel
+phase_diffractive = ngs.phase
+amp_diff_scint = ngs.scintillation
+
+# CASE 3: Geometric + Scintillation (OOPAO Optimized)
+atm.geometric_phase_backup = True
+ngs ** atm * tel
+phase_geom_scint = ngs.phase
+amp_geom_scint = ngs.scintillation
+atm.geometric_phase_backup = False # Reset for next case
+
+# CASE 4: Unwrapped phase + scintillation 
+atm.unwrap_diffractive_phase = True
+ngs ** atm * tel
+phase_unwrapped = ngs.phase
+amp_unwrap = ngs.scintillation
+atm.unwrap_diffractive_phase = False # Reset
+
+# --- PLOTTING SETUP ---
+
+# Zoom setup
+N_padded = phase_diffractive.shape[0]  
+N_phys = tel.initial_resolution  
+marge_px = 10
+idx_min_base = (N_padded - N_phys) // 2
+idx_max_base = idx_min_base + N_phys
+idx_min = max(0, idx_min_base - marge_px)
+idx_max = min(N_padded, idx_max_base + marge_px)
+
+# ---  THE 4 REGIMES COMPARISON ---
+fig, axs = plt.subplots(2, 4, figsize=(16, 8))
+fig.suptitle('Wavefront Regimes Comparison', fontsize=16)
+
+# Row 1: Phase (Corrected colorbars and variables)
+im0 = axs[0, 0].imshow(phase_diffractive, cmap='plasma')
+axs[0, 0].set_title('Phase: Diffractive (Wrapped)')
+fig.colorbar(im0, ax=axs[0, 0], fraction=0.046, pad=0.04)
+
+im1 = axs[0, 1].imshow(phase_unwrapped, cmap='plasma')
+axs[0, 1].set_title('Phase: Unwrapped')
+fig.colorbar(im1, ax=axs[0, 1], fraction=0.046, pad=0.04)
+
+im2 = axs[0, 2].imshow(phase_geom_scint, cmap='plasma')
+axs[0, 2].set_title('Phase: Geom + Scint')
+fig.colorbar(im2, ax=axs[0, 2], fraction=0.046, pad=0.04)
+
+im3 = axs[0, 3].imshow(phase_geom, cmap='plasma')
+axs[0, 3].set_title('Phase: Pure Geometric')
+fig.colorbar(im3, ax=axs[0, 3], fraction=0.046, pad=0.04)
+
+# Row 2: Amplitude (Corrected to show proper amplitude vars and colorbars)
+im4 = axs[1, 0].imshow(amp_diff_scint, cmap='viridis') 
+axs[1, 0].set_title('Amplitude: Diffractive')
+fig.colorbar(im4, ax=axs[1, 0], fraction=0.046, pad=0.04)
+
+im5 = axs[1, 1].imshow(amp_unwrap, cmap='viridis')
+axs[1, 1].set_title('Amplitude: Unwrapped')
+fig.colorbar(im5, ax=axs[1, 1], fraction=0.046, pad=0.04)
+
+im6 = axs[1, 2].imshow(amp_geom_scint, cmap='viridis')
+axs[1, 2].set_title('Amplitude: Geom + Scint')
+fig.colorbar(im6, ax=axs[1, 2], fraction=0.046, pad=0.04)
+
+im7 = axs[1, 3].imshow(amp_geom, cmap='viridis')
+axs[1, 3].set_title('Amplitude: Pure Geom (Flat)')
+fig.colorbar(im7, ax=axs[1, 3], fraction=0.046, pad=0.04)
+
+
+for ax in axs.flat:
+    ax.set_xlim(idx_min, idx_max)
+    ax.set_ylim(idx_max, idx_min) 
+
+plt.tight_layout()
+plt.show()
+
+# --- PHASE DIFFERENCES (RESIDUALS) ---
+fig2, axs2 = plt.subplots(1, 3, figsize=(16, 5))
+fig2.suptitle('Phase Differences Analysis', fontsize=16)
+
+# 1. Unwrapped vs Geometric -> Reveals the pure diffractive residual (the "ripples")
+diff1 = phase_unwrapped - phase_geom
+# Use symmetric scaling around 0 for residuals
+v_max1 = np.max(np.abs(diff1))
+im_d1 = axs2[0].imshow(diff1, cmap='RdBu', vmin=-v_max1, vmax=v_max1)
+axs2[0].set_title('Unwrapped - Geometric\n(= Diffractive Residual)')
+fig2.colorbar(im_d1, ax=axs2[0], fraction=0.046, pad=0.04)
+
+# 2. Diffractive vs Geometric -> Shows wrapping artifacts + residual
+diff2 = phase_diffractive - phase_geom
+v_max2 = np.max(np.abs(diff2))
+im_d2 = axs2[1].imshow(diff2, cmap='RdBu', vmin=-v_max2, vmax=v_max2)
+axs2[1].set_title('Diffractive (Wrapped) - Geometric')
+fig2.colorbar(im_d2, ax=axs2[1], fraction=0.046, pad=0.04)
+
+# 3. Unwrapped vs Diffractive -> Shows the 2π macroscopic steps that were restored
+diff3 = phase_unwrapped - phase_diffractive
+v_max3 = np.max(np.abs(diff3))
+im_d3 = axs2[2].imshow(diff3, cmap='RdBu', vmin=-v_max3, vmax=v_max3)
+axs2[2].set_title('Unwrapped - Diffractive\n(= Macroscopic Phase Jumps)')
+fig2.colorbar(im_d3, ax=axs2[2], fraction=0.046, pad=0.04)
+
+for ax in axs2:
+    ax.set_xlim(idx_min, idx_max)
+    ax.set_ylim(idx_max, idx_min)
+
+plt.tight_layout()
+plt.show()
+
+ 
+
+#%% -----------------------     DEFORMABLE MIRROR   ----------------------------------
+from OOPAO.DeformableMirror import DeformableMirror
+physical_pitch = tel.initial_D / n_subaperture
+
+# 2. Calculate the equivalent number of subapertures across the ENTIRE padded grid
+n_subap_simu = int(round(tel.D / physical_pitch))
+# specifying a given number of actuators along the diameter: 
+dm = DeformableMirror(telescope  = tel,                        # Telescope
+                    nSubap       = n_subap_simu,                     # number of subaperture of the system considered (by default the DM has n_subaperture + 1 actuators to be in a Fried Geometry)
+                    mechCoupling = 0.35,                       # Mechanical Coupling for the influence functions
+                    coordinates  = None,                       # coordinates in [m]. Should be input as an array of size [n_actuators, 2] 
+                    pitch        = physical_pitch)                 # inter actuator distance. Only used to compute the influence function coupling. The default is based on the n_subaperture value. 
+    
+
+# plot the dm actuators coordinates with respect to the pupil
+
+dm.display_dm()
+plt.plot(dm.coordinates[:,0],dm.coordinates[:,1],'rx')
+plt.xlabel('[m]')
+plt.ylabel('[m]')
+plt.title('DM Actuator Coordinates')
+#%% -----------------------     Propagation to WFS   ----------------------------------
+"""
+In OOPAO, coupling scintillation with Wavefront Sensors is completely seamless. 
+When `atm.angular_spectrum_propagation = True`, the framework automatically propagates the 
+full complex electromagnetic field (both phase aberrations and amplitude 
+fluctuations) through the optical chain. 
+"""
+print("\n--- 5. Initializing Wavefront Sensors ---")
+
+pixels_per_subap = tel.initial_resolution / n_subaperture
+n_subap_padded_wfs = int(tel.resolution / pixels_per_subap)
+
+# Initialize PWFS
+pwfs = Pyramid(nSubap=n_subap_padded_wfs, telescope=tel, lightRatio=0.5, modulation=5, 
+               binning=1, n_pix_separation=2, n_pix_edge=1, postProcessing='slopesMaps') 
+
+# Initialize SHWFS
+shwfs = ShackHartmann(nSubap=n_subap_padded_wfs, telescope=tel, lightRatio=0.5, is_geometric=False)
+
+# --- Test With Scintillation ---
+atm.angular_spectrum_propagation = True
+atm.unwrap_diffractive_phase = True
+ngs ** atm * tel
+ngs * pwfs
+ngs * shwfs
+pwfs_frame_scint = pwfs.cam.frame.copy()
+shwfs_frame_scint = shwfs.cam.frame.copy()
+
+# --- Test Without Scintillation ---
+atm.angular_spectrum_propagation = False
+atm.unwrap_diffractive_phase = False # Reset for normal propagation
+ngs ** atm * tel
+ngs * pwfs
+ngs * shwfs
+pwfs_frame_no_scint = pwfs.cam.frame.copy()
+shwfs_frame_no_scint = shwfs.cam.frame.copy()
+
+# --- Compute Differences and Sums ---
+diff_pwfs = pwfs_frame_scint - pwfs_frame_no_scint
+diff_shwfs = shwfs_frame_scint - shwfs_frame_no_scint
+
+# SHWFS Sums
+sum_sh_no_scint = np.sum(shwfs_frame_no_scint)
+sum_sh_scint = np.sum(shwfs_frame_scint)
+sum_sh_diff = np.sum(diff_shwfs)
+
+# PWFS Sums
+sum_pwfs_no_scint = np.sum(pwfs_frame_no_scint)
+sum_pwfs_scint = np.sum(pwfs_frame_scint)
+sum_pwfs_diff = np.sum(diff_pwfs)
+
+# ============================================================================
+# --- PLOTTING SHWFS ---
+# ============================================================================
+marge_px_shwfs = 10
+N_padded_shwfs = shwfs_frame_no_scint.shape[0]
+N_phys_shwfs = tel.initial_resolution 
+
+idx_min_shwfs = max(0, (N_padded_shwfs - N_phys_shwfs) // 2 - marge_px_shwfs)
+idx_max_shwfs = min(N_padded_shwfs, (N_padded_shwfs - N_phys_shwfs) // 2 + N_phys_shwfs + marge_px_shwfs)
+
+val_max_shwfs = np.max(shwfs_frame_no_scint) * 0.8 
+
+fig, axs = plt.subplots(1, 3, figsize=(15, 5))
+fig.suptitle('Impact of Scintillation on SHWFS Camera', fontsize=14)
+
+im0 = axs[0].imshow(shwfs_frame_no_scint, cmap='magma', vmin=0, vmax=val_max_shwfs)
+axs[0].set_title(f'Without Scintillation\nSum = {sum_sh_no_scint:.2e}')
+fig.colorbar(im0, ax=axs[0], fraction=0.046, pad=0.04)
+
+im1 = axs[1].imshow(shwfs_frame_scint, cmap='magma', vmin=0, vmax=val_max_shwfs)
+axs[1].set_title(f'With Scintillation\nSum = {sum_sh_scint:.2e}')
+fig.colorbar(im1, ax=axs[1], fraction=0.046, pad=0.04)
+
+val_max_diff = np.max(np.abs(diff_shwfs)) * 0.8
+im2 = axs[2].imshow(diff_shwfs, cmap='RdBu_r', vmin=-val_max_diff, vmax=val_max_diff)
+axs[2].set_title(f'Difference (Scint - No Scint)\nSum = {sum_sh_diff:.2e}')
+fig.colorbar(im2, ax=axs[2], fraction=0.046, pad=0.04)
+
+for ax in axs:
+    ax.set_xlim(idx_min_shwfs, idx_max_shwfs)
+    ax.set_ylim(idx_max_shwfs, idx_min_shwfs)
+
+plt.tight_layout()
+plt.show()
+
+# ============================================================================
+# --- PLOTTING PWFS ---
+# ============================================================================
+marge_px_pwfs = 0 
+N_padded_pwfs = pwfs_frame_no_scint.shape[0]
+N_phys_pwfs = tel.initial_resolution 
+
+idx_min_pwfs = max(0, (N_padded_pwfs - N_phys_pwfs) // 2 - marge_px_pwfs)
+idx_max_pwfs = min(N_padded_pwfs, (N_padded_pwfs - N_phys_pwfs) // 2 + N_phys_pwfs + marge_px_pwfs)
+
+val_max_pwfs = max(np.max(pwfs_frame_no_scint), np.max(pwfs_frame_scint))
+
+fig, axs = plt.subplots(1, 3, figsize=(15, 5))
+fig.suptitle('Impact of Scintillation on Pyramid WFS Camera', fontsize=14)
+
+im0 = axs[0].imshow(pwfs_frame_no_scint, cmap='plasma', vmin=0, vmax=val_max_pwfs)
+axs[0].set_title(f'Without Scintillation\nSum = {sum_pwfs_no_scint:.2e}')
+fig.colorbar(im0, ax=axs[0], fraction=0.046, pad=0.04)
+
+im1 = axs[1].imshow(pwfs_frame_scint, cmap='plasma', vmin=0, vmax=val_max_pwfs)
+axs[1].set_title(f'With Scintillation\nSum = {sum_pwfs_scint:.2e}')
+fig.colorbar(im1, ax=axs[1], fraction=0.046, pad=0.04)
+
+val_max_diff_pwfs = np.max(np.abs(diff_pwfs))
+im2 = axs[2].imshow(diff_pwfs, cmap='coolwarm', vmin=-val_max_diff_pwfs, vmax=val_max_diff_pwfs)
+axs[2].set_title(f'Difference (Scint - No Scint)\nSum = {sum_pwfs_diff:.2e}')
+fig.colorbar(im2, ax=axs[2], fraction=0.046, pad=0.04)
+
+for ax in axs:
+    ax.set_xlim(idx_min_pwfs, idx_max_pwfs)
+    ax.set_ylim(idx_max_pwfs, idx_min_pwfs)
+
+plt.tight_layout()
+plt.show()
+
+
+#%% -----------------------     Modal Basis - KL Basis  ----------------------------------
+
+
+from OOPAO.calibration.compute_KL_modal_basis import compute_KL_basis
+# use the default definition of the KL modes with forced Tip and Tilt. For more complex KL modes, consider the use of the compute_KL_basis function. 
+M2C_KL = compute_KL_basis(tel,
+                          atm,
+                          dm,
+                          lim = 0) # inversion stability criterion
+
+# apply the 10 first KL modes
+dm.coefs = M2C_KL[:,:10]
+# propagate through the DM
+ngs**tel*dm
+# show the first 10 KL modes applied on the DM
+displayMap(tel.OPD)
+#%% -----------------------     Calibration: Interaction Matrix PWFS  ----------------------------------
+
+# amplitude of the modes in m
+stroke=1e-9
+# zonal Interaction Matrix
+M2C_zonal = np.eye(dm.nValidAct)
+
+# modal Interaction Matrix for 300 modes
+M2C_modal = M2C_KL[:,:300]
+
+# swap to geometric WFS for the calibration
+ngs**tel*pwfs # make sure that the proper source is propagated to the WFS
+# zonal interaction matrix
+calib_modal_pwfs = InteractionMatrix(ngs            = ngs,
+                                atm            = atm,
+                                tel            = tel,
+                                dm             = dm,
+                                wfs            = pwfs,   
+                                M2C            = M2C_modal, # M2C matrix used 
+                                stroke         = stroke,    # stroke for the push/pull in M2C units
+                                nMeasurements  = 12,        # number of simultaneous measurements
+                                noise          = 'off',     # disable wfs.cam noise 
+                                display        = True,      # display the time using tqdm
+                                single_pass    = True)      # only push to compute the interaction matrix instead of push-pull
+
+
+plt.figure()
+plt.plot(np.std(calib_modal_pwfs.D,axis=0))
+plt.xlabel('Mode Number')
+plt.ylabel('WFS slopes STD')
+
+#%% -----------------------     Calibration: Interaction Matrix SHWFS  ----------------------------------
+# amplitude of the modes in m
+stroke=1e-9
+# zonal Interaction Matrix
+M2C_zonal = np.eye(dm.nValidAct)
+
+# modal Interaction Matrix for 300 modes
+M2C_modal = M2C_KL[:,:300]
+atm.angular_spectrum_propagation = False
+# swap to geometric WFS for the calibration
+ngs**tel*shwfs # make sure that the proper source is propagated to the WFS
+# zonal interaction matrix
+shwfs.is_geometric = True
+
+calib_modal_shwfs = InteractionMatrix(ngs            = ngs,
+                                atm            = atm,
+                                tel            = tel,
+                                dm             = dm,
+                                wfs            = shwfs,   
+                                M2C            = M2C_modal, # M2C matrix used 
+                                stroke         = stroke,    # stroke for the push/pull in M2C units
+                                nMeasurements  = 12,        # number of simultaneous measurements
+                                noise          = 'off',     # disable wfs.cam noise 
+                                display        = True,      # display the time using tqdm
+                                single_pass    = True)      # only push to compute the interaction matrix instead of push-pull
+
+
+plt.figure()
+plt.plot(np.std(calib_modal_shwfs.D,axis=0))
+plt.xlabel('Mode Number')
+plt.ylabel('WFS slopes STD')
+shwfs.is_geometric = False
+
+#%% Define instrument and WFS path detectors
+from OOPAO.Detector import Detector
+# instrument path
+src_cam = Detector(tel.resolution*2)
+src_cam.psf_sampling = 4  # sampling of the PSF
+src_cam.integrationTime = tel.samplingTime # exposure time for the PSF
+
+# put the scientific target off-axis to simulate anisoplanetism (set to  [0,0] to remove anisoplanetism)
+src.coordinates = [1,0]
+
+# WFS path
+ngs_cam = Detector(tel.resolution*2)
+ngs_cam.psf_sampling = 4
+ngs_cam.integrationTime = tel.samplingTime
+
+ngs**tel*ngs_cam
+ngs_psf_ref = ngs_cam.frame.copy()
+
+src**tel*src_cam
+
+src_psf_ref = src_cam.frame.copy()
+
+#%%  Closed loop simulation with a PWFS
+from OOPAO.tools.tools import strehlMeter
+
+atm.angular_spectrum_propagation = True
+atm.unwrap_diffractive_phase = True
+plt.close('all')
+
+# These are the calibration data used to close the loop
+calib_CL = calib_modal_pwfs
+# calib_CL = calib_modal_shwfs
+M2C_CL = M2C_modal
+reconstructor = M2C_CL@calib_CL.M 
+
+# initialize Telescope DM commands
+dm.coefs=0
+
+# To make sure to always replay the same turbulence, generate a new phase screen for the atmosphere and combine it with the Telescope
+atm.generateNewPhaseScreen(seed=10)
+
+# combine telescope with atmosphere
+tel+atm
+
+# propagate both sources
+ngs**atm*tel*ngs_cam
+src**atm*tel*src_cam
+
+# loop parameters
+nLoop = 100  # number of iterations
+gainCL = 0.4  # integrator gain
+pwfs.cam.photonNoise = False  # enable photon noise on the WFS camera
+display = True  # enable the display
+frame_delay = 2  # number of frame delay
+
+# variables used to to save closed-loop data data
+SR_ngs = np.zeros(nLoop)
+SR_src = np.zeros(nLoop)
+
+wfe_atmosphere = np.zeros(nLoop)
+wfe_residual_SRC = np.zeros(nLoop)
+wfe_residual_NGS = np.zeros(nLoop)
+wfsSignal = np.arange(0, pwfs.nSignal)*0  # buffer to simulate the loop delay
+
+# configure the display pannel
+plot_obj = cl_plot(list_fig=[atm.OPD,  # list of data for the different subplots
+                             tel.OPD,
+                             tel.OPD,
+                             pwfs.cam.frame,
+                             ngs.scintillation,
+                             [[0, 0], [0, 0], [0, 0]],
+                             np.log10(ngs_cam.frame),
+                             np.log10(src_cam.frame)],
+                   type_fig=['imshow',  # type of figure for the different subplots
+                             'imshow',
+                             'imshow',
+                             'imshow',
+                             'imshow',
+                             'plot',
+                             'imshow',
+                             'imshow'],
+                   list_title=['Turbulence [nm]',  # list of title for the different subplots
+                               'NGS residual [m]',
+                               'SRC residual [m]',
+                               'WFS Detector',
+                               'NGS EM Intensity',
+                               None,
+                               None,
+                               None],
+                   list_legend=[None,  # list of legend labels for the subplots
+                                None,
+                                None,
+                                None,
+                                None,
+                                ['SRC@'+str(src.coordinates[0])+'"', 'NGS@'+str(ngs.coordinates[0])+'"'],
+                                None,
+                                None],
+                   list_label=[None,  # list of axis labels for the subplots
+                               None,
+                               None,
+                               None,
+                               None,
+                               ['Time', 'WFE [nm]'],
+                               ['NGS PSF@' + str(ngs.coordinates[0]) + '" -- FOV: ' + str(np.round(ngs_cam.fov_arcsec, 2)) + '"', ''],
+                               ['SRC PSF@' + str(src.coordinates[0]) + '" -- FOV: ' + str(np.round(src_cam.fov_arcsec, 2)) + '"', '']],
+                   n_subplot=[4, 2],
+                   list_display_axis=[None,  # list of the subplot for which axis are displayed
+                                      None,
+                                      None,
+                                      None,
+                                      None,
+                                      True,
+                                      None,
+                                      None],
+                   list_ratio=[[0.95, 0.95, 0.1],
+                               [1, 1, 1, 1]],
+                   s=20)  # size of the scatter markers
+
+
+for i in range(nLoop):
+    a = time.time()
+    # update phase screens => overwrite tel.OPD and consequently tel.src.phase
+    atm.update()
+    # save the wave-front error of the incoming turbulence within the pupil
+    wfe_atmosphere[i] = np.std(tel.OPD[np.where(tel.pupil > 0)])*1e9
+    # propagate light from the ngs through the atmosphere, telescope, DM to the WFS and ngs camera
+    ngs**atm*tel*dm*pwfs*ngs_cam
+    # save residuals corresponding to the ngs
+    wfe_residual_NGS[i] = np.std(tel.OPD[np.where(tel.pupil > 0)])*1e9
+    # save Strehl ratio from the PSF image
+    SR_ngs[i] = strehlMeter(PSF=ngs_cam.frame, tel=tel, PSF_ref=ngs_psf_ref, display=False)
+    # save the OPD seen by the ngs
+    OPD_NGS = ngs.OPD.copy()
+    if display:
+        NGS_PSF = np.log10(np.abs(ngs_cam.frame))
+    # propagate light from the src through the atmosphere, telescope, DM to the src camera
+    src**atm*tel*dm*src_cam
+    # save residuals corresponding to the SRC
+    wfe_residual_SRC[i] = np.std(tel.OPD[np.where(tel.pupil > 0)])*1e9
+    # save the OPD seen by the src
+    OPD_SRC = src.OPD.copy()
+    # save Strehl ratio from the PSF image
+    SR_src[i] = strehlMeter(PSF=src_cam.frame, tel=tel, PSF_ref=src_psf_ref, display=False)
+
+    # store the slopes after propagating to the WFS <=> 1 frames delay
+    if frame_delay == 1:
+        wfsSignal = pwfs.signal
+
+    # apply the commands on the DM
+    dm.coefs = dm.coefs - gainCL*np.matmul(reconstructor, wfsSignal)
+
+    # store the slopes after computing the commands <=> 2 frames delay
+    if frame_delay == 2:
+        wfsSignal = pwfs.signal
+    # print('Elapsed time: ' + str(time.time()-a) + ' s')
+
+    # update displays if required
+    if display and i > 1:
+        SRC_PSF = np.log10(np.abs(src_cam.frame))
+        # update range for PSF images
+        plot_obj.list_lim = [None,
+                             None,
+                             None,
+                             None,
+                             None,
+                             None,
+                             [NGS_PSF.max()-6, NGS_PSF.max()],
+                             [SRC_PSF.max()-6, SRC_PSF.max()]]
+        # update title
+        plot_obj.list_title = ['Turbulence '+str(np.round(wfe_atmosphere[i]))+'[nm]',
+                               'NGS residual '+str(np.round(wfe_residual_NGS[i]))+'[nm]',
+                               'SRC residual '+str(np.round(wfe_residual_SRC[i]))+'[nm]',
+                               'WFS Detector',
+                               'NGS EM Intensity',
+                               None,
+                               None,
+                               None]
+
+        cl_plot(list_fig=[1e9*atm.OPD,
+                          1e9*OPD_NGS,
+                          1e9*OPD_SRC,
+                          pwfs.cam.frame,
+                          ngs.scintillation,
+                          [np.arange(i+1), wfe_residual_SRC[:i+1], wfe_residual_NGS[:i+1]],
+                          NGS_PSF,
+                          SRC_PSF],
+                plt_obj=plot_obj)
+        plt.pause(0.01)
+        if plot_obj.keep_going is False:
+            break
+    print('-----------------------------------')
+    print('Loop'+str(i) + '/' + str(nLoop))
+    print('NGS: Strehl ratio [%] : ', np.round(SR_ngs[i],1), ' WFE [nm] : ', np.round(wfe_residual_NGS[i],2))
+    print('SRC: Strehl ratio [%] : ', np.round(SR_src[i],1), ' WFE [nm] : ', np.round(wfe_residual_SRC[i],2))
+
+    
+    
+#%% Closed Loop data analysis
+
+plt.figure()
+plt.plot(np.arange(nLoop)*tel.samplingTime, wfe_atmosphere, label='Turbulence')
+plt.plot(np.arange(nLoop)*tel.samplingTime, wfe_residual_NGS, label='NGS')
+plt.plot(np.arange(nLoop)*tel.samplingTime, wfe_residual_SRC, label='SRC')
+plt.legend()
+plt.xlabel('Time [s]')
+plt.ylabel('WFE [nm]')
+
+plt.figure()
+plt.plot(np.arange(nLoop)*tel.samplingTime, SR_ngs, label='NGS@' + str(np.round(1e9*ngs.wavelength,0)) + ' nm')
+plt.plot(np.arange(nLoop)*tel.samplingTime, SR_src, label='SRC@' + str(np.round(1e9*src.wavelength,0)) + ' nm')
+plt.legend()
+plt.xlabel('Time [s]')
+plt.ylabel('SR [%]')
+
+
+
+#%%  Closed loop simulation with a SHWFS
+from OOPAO.tools.tools import strehlMeter
+
+plt.close('all')
+
+# These are the calibration data used to close the loop
+calib_CL = calib_modal_shwfs
+# calib_CL = calib_modal_shwfs
+M2C_CL = M2C_modal
+reconstructor = M2C_CL@calib_CL.M 
+
+# initialize Telescope DM commands
+dm.coefs=0
+
+atm.angular_spectrum_propagation = True
+atm.unwrap_diffractive_phase = True
+
+# To make sure to always replay the same turbulence, generate a new phase screen for the atmosphere and combine it with the Telescope
+atm.generateNewPhaseScreen(seed=10)
+
+# combine telescope with atmosphere
+tel+atm
+
+# propagate both sources
+ngs**atm*tel*ngs_cam
+src**atm*tel*src_cam
+
+# loop parameters
+nLoop = 500  # number of iterations
+gainCL = 0.4  # integrator gain
+shwfs.cam.photonNoise = False  # enable photon noise on the WFS camera
+display = True  # enable the display
+frame_delay = 2  # number of frame delay
+
+# variables used to to save closed-loop data data
+SR_ngs = np.zeros(nLoop)
+SR_src = np.zeros(nLoop)
+
+wfe_atmosphere = np.zeros(nLoop)
+wfe_residual_SRC = np.zeros(nLoop)
+wfe_residual_NGS = np.zeros(nLoop)
+wfsSignal = np.arange(0, shwfs.nSignal)*0  # buffer to simulate the loop delay
+
+# configure the display pannel
+plot_obj = cl_plot(list_fig=[atm.OPD,  # list of data for the different subplots
+                             tel.OPD,
+                             tel.OPD,
+                             shwfs.cam.frame,
+                             ngs.scintillation,
+                             [[0, 0], [0, 0], [0, 0]],
+                             np.log10(ngs_cam.frame),
+                             np.log10(src_cam.frame)],
+                   type_fig=['imshow',  # type of figure for the different subplots
+                             'imshow',
+                             'imshow',
+                             'imshow',
+                             'imshow',
+                             'plot',
+                             'imshow',
+                             'imshow'],
+                   list_title=['Turbulence [nm]',  # list of title for the different subplots
+                               'NGS residual [m]',
+                               'SRC residual [m]',
+                               'WFS Detector',
+                               'NGS EM Intensity',
+                               None,
+                               None,
+                               None],
+                   list_legend=[None,  # list of legend labels for the subplots
+                                None,
+                                None,
+                                None,
+                                None,
+                                ['SRC@'+str(src.coordinates[0])+'"', 'NGS@'+str(ngs.coordinates[0])+'"'],
+                                None,
+                                None],
+                   list_label=[None,  # list of axis labels for the subplots
+                               None,
+                               None,
+                               None,
+                               None,
+                               ['Time', 'WFE [nm]'],
+                               ['NGS PSF@' + str(ngs.coordinates[0]) + '" -- FOV: ' + str(np.round(ngs_cam.fov_arcsec, 2)) + '"', ''],
+                               ['SRC PSF@' + str(src.coordinates[0]) + '" -- FOV: ' + str(np.round(src_cam.fov_arcsec, 2)) + '"', '']],
+                   n_subplot=[4, 2],
+                   list_display_axis=[None,  # list of the subplot for which axis are displayed
+                                      None,
+                                      None,
+                                      None,
+                                      None,
+                                      True,
+                                      None,
+                                      None],
+                   list_ratio=[[0.95, 0.95, 0.1],
+                               [1, 1, 1, 1]],
+                   s=20)  # size of the scatter markers
+
+
+for i in range(nLoop):
+    a = time.time()
+    # update phase screens => overwrite tel.OPD and consequently tel.src.phase
+    atm.update()
+    # save the wave-front error of the incoming turbulence within the pupil
+    wfe_atmosphere[i] = np.std(tel.OPD[np.where(tel.pupil > 0)])*1e9
+    # propagate light from the ngs through the atmosphere, telescope, DM to the WFS and ngs camera
+    ngs**atm*tel*dm*shwfs*ngs_cam
+    # save residuals corresponding to the ngs
+    wfe_residual_NGS[i] = np.std(tel.OPD[np.where(tel.pupil > 0)])*1e9
+    # save Strehl ratio from the PSF image
+    SR_ngs[i] = strehlMeter(PSF=ngs_cam.frame, tel=tel, PSF_ref=ngs_psf_ref, display=False)
+    # save the OPD seen by the ngs
+    OPD_NGS = ngs.OPD.copy()
+    if display:
+        NGS_PSF = np.log10(np.abs(ngs_cam.frame))
+
+    # propagate light from the src through the atmosphere, telescope, DM to the src camera
+    src**atm*tel*dm*src_cam
+    # save residuals corresponding to the SRC
+    wfe_residual_SRC[i] = np.std(tel.OPD[np.where(tel.pupil > 0)])*1e9
+    # save the OPD seen by the src
+    OPD_SRC = src.OPD.copy()
+    # save Strehl ratio from the PSF image
+    SR_src[i] = strehlMeter(PSF=src_cam.frame, tel=tel, PSF_ref=src_psf_ref, display=False)
+
+    # store the slopes after propagating to the WFS <=> 1 frames delay
+    if frame_delay == 1:
+        wfsSignal = shwfs.signal
+
+    # apply the commands on the DM
+    dm.coefs = dm.coefs - gainCL*np.matmul(reconstructor, wfsSignal)
+
+    # store the slopes after computing the commands <=> 2 frames delay
+    if frame_delay == 2:
+        wfsSignal = shwfs.signal
+    # print('Elapsed time: ' + str(time.time()-a) + ' s')
+
+    # update displays if required
+    if display and i > 1:
+        SRC_PSF = np.log10(np.abs(src_cam.frame))
+        # update range for PSF images
+        plot_obj.list_lim = [None,
+                             None,
+                             None,
+                             None,
+                             None,
+                             None,
+                             [NGS_PSF.max()-6, NGS_PSF.max()],
+                             [SRC_PSF.max()-6, SRC_PSF.max()]]
+        # update title
+        plot_obj.list_title = ['Turbulence '+str(np.round(wfe_atmosphere[i]))+'[nm]',
+                               'NGS residual '+str(np.round(wfe_residual_NGS[i]))+'[nm]',
+                               'SRC residual '+str(np.round(wfe_residual_SRC[i]))+'[nm]',
+                               'WFS Detector',
+                               'NGS EM Intensity',
+                               None,
+                               None,
+                               None]
+
+        cl_plot(list_fig=[1e9*atm.OPD,
+                          1e9*OPD_NGS,
+                          1e9*OPD_SRC,
+                          shwfs.cam.frame,
+                          ngs.scintillation,
+                          [np.arange(i+1), wfe_residual_SRC[:i+1], wfe_residual_NGS[:i+1]],
+                          NGS_PSF,
+                          SRC_PSF],
+                plt_obj=plot_obj)
+        plt.pause(0.01)
+        if plot_obj.keep_going is False:
+            break
+    print('-----------------------------------')
+    print('Loop'+str(i) + '/' + str(nLoop))
+    print('NGS: Strehl ratio [%] : ', np.round(SR_ngs[i],1), ' WFE [nm] : ', np.round(wfe_residual_NGS[i],2))
+    print('SRC: Strehl ratio [%] : ', np.round(SR_src[i],1), ' WFE [nm] : ', np.round(wfe_residual_SRC[i],2))
+
+    
+    
+#%% Closed Loop data analysis
+
+plt.figure()
+plt.plot(np.arange(nLoop)*tel.samplingTime, wfe_atmosphere, label='Turbulence')
+plt.plot(np.arange(nLoop)*tel.samplingTime, wfe_residual_NGS, label='NGS')
+plt.plot(np.arange(nLoop)*tel.samplingTime, wfe_residual_SRC, label='SRC')
+plt.legend()
+plt.xlabel('Time [s]')
+plt.ylabel('WFE [nm]')
+
+plt.figure()
+plt.plot(np.arange(nLoop)*tel.samplingTime, SR_ngs, label='NGS@' + str(np.round(1e9*ngs.wavelength,0)) + ' nm')
+plt.plot(np.arange(nLoop)*tel.samplingTime, SR_src, label='SRC@' + str(np.round(1e9*src.wavelength,0)) + ' nm')
+plt.legend()
+plt.xlabel('Time [s]')
+plt.ylabel('SR [%]')
+
+
+


### PR DESCRIPTION
- Add the Angular Spectrum propagation method through the atmosphere to allow the simulation of scintillation cases

- Add the propagation of non-constant amplitude to the PWFS, SHWFS, and BioEdge

- The scintillation map is carried by the source, just like the OPD and the phase

- Add an unwrapping method to use the diffractive phase and propagation modes to the atmosphere

- Add a tutorial demonstrating how to simulate a scintillation case and showing the tools around it

- Add metrics for scintillation (PSD, Rytov variance)

- Add a method to simulate specific Rytov variance cases